### PR TITLE
Adding NPM deployment to .travis.yaml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,12 @@ node_js:
 script:
   - npm run build
   - npm run test
+
+deploy:
+  provider: npm
+  email: $NPM_EMAIL
+  api_key: $NPM_API_KEY
+  on:
+    tags: true
+  # make sure we keep our dist directory
+  skip_cleanup: true


### PR DESCRIPTION
Before merging this in, we need to set two environment variables on Travis CI.

* NPM_EMAIL - set to the email that is used to publish this module.
* NPM_API_KEY - a key used to publish this module. Checking the [docs](https://www.npmjs.com/settings/tokens) for more information.

resolves #38