### PR TITLE
added Intersection observer options root

### DIFF
--- a/src/lozad.js
+++ b/src/lozad.js
@@ -66,11 +66,12 @@ const getElements = selector => {
 }
 
 export default function (selector = '.lozad', options = {}) {
-  const {rootMargin, threshold, load, loaded} = {...defaultConfig, ...options}
+  const {root, rootMargin, threshold, load, loaded} = {...defaultConfig, ...options}
   let observer
 
   if (window.IntersectionObserver) {
     observer = new IntersectionObserver(onIntersection(load, loaded), {
+      root,
       rootMargin,
       threshold
     })


### PR DESCRIPTION
The element that is used as the viewport for checking visiblity of the target. Must be the ancestor of the target. Defaults to the browser viewport if not specified or if null