### PR TITLE
Improve compatibility of data-srcset with older browsers

### DIFF
--- a/src/lozad.js
+++ b/src/lozad.js
@@ -23,7 +23,7 @@ const defaultConfig = {
       element.src = element.getAttribute('data-src')
     }
     if (element.getAttribute('data-srcset')) {
-      element.srcset = element.getAttribute('data-srcset')
+      element.setAttribute('srcset', element.getAttribute('data-srcset'))
     }
     if (element.getAttribute('data-background-image')) {
       element.style.backgroundImage = `url('${element.getAttribute('data-background-image')}')`


### PR DESCRIPTION
**Issue: #142**

The direct manipulation of an attribute like `srcset` is only possible for supported attributes. The `srcset` attribute is not supported in older browsers, including IE9-11. Using `setAttribute()` will work for older browsers as well.