### PR TITLE
fix server side rendering issue

### DIFF
--- a/src/lozad.js
+++ b/src/lozad.js
@@ -82,7 +82,7 @@ export default function (selector = '.lozad', options = {}) {
   const {root, rootMargin, threshold, load, loaded} = {...defaultConfig, ...options}
   let observer
 
-  if (window.IntersectionObserver) {
+  if (typeof window !== 'undefined' && window.IntersectionObserver) {
     observer = new IntersectionObserver(onIntersection(load, loaded), {
       root,
       rootMargin,


### PR DESCRIPTION
Same as https://github.com/ApoorvSaxena/lozad.js/pull/119

We are using lozad in the react app with server side rendering. Our app was crashing on server side rendering because window doesn't exist in node.js (`ReferenceError: window is not defined`). This change is fixing that issue.