### PR TITLE
fix: use Object.assign over rest/spread for better ES support

### DIFF
--- a/src/lozad.js
+++ b/src/lozad.js
@@ -89,7 +89,7 @@ const getElements = (selector, root = document) => {
 }
 
 export default function (selector = '.lozad', options = {}) {
-  const {root, rootMargin, threshold, load, loaded} = {...defaultConfig, ...options}
+  const {root, rootMargin, threshold, load, loaded} = Object.assign({}, defaultConfig, options)
   let observer
 
   if (typeof window !== 'undefined' && window.IntersectionObserver) {


### PR DESCRIPTION
Hey!

I was trying to use this library in a project I'm working on, but encountered an issue with Edge which does not support Object Rest/Spread syntax. I'm using the `module` (`lozad.es.js`) bundle to benefit from ES6 import/export syntax, but unfortunately that includes the `...` Object rest syntax which causes Edge 18 (as well as Firefox 60 ESR) to throw a Syntax Error.

This PR changes the use of Object rest syntax to instead use `Object.assign` which does the same thing, and is available in Edge 12+ and Firefox 34+. 

This PR will allow us to use the es bundle, and still benefit from import syntax, but also be able to serve it to older browsers without throwing an early Syntax Error.