### PR TITLE
Only accept direct child imgs when determing If picture is loaded

### DIFF
--- a/src/lozad.js
+++ b/src/lozad.js
@@ -21,6 +21,9 @@ const defaultConfig = {
   load(element) {
     if (element.nodeName.toLowerCase() === 'picture') {
       let img = element.querySelector('img')
+      if (img !== null && img.parentElement.nodeName.toLowerCase() !== 'picture') {
+        img = null
+      }
       let append = false
 
       if (img === null) {


### PR DESCRIPTION
Otherwise it won't work If the picture element has a fallback img inside of a script tag (the img in the script tag is selected and no new img element is appended to the picture element).

This fix is needed when dynamically adding picture elements with fallback img in a noscript tag.