### PR TITLE
Added data-style to picture element

### DIFF
--- a/dist/lozad.es.js
+++ b/dist/lozad.es.js
@@ -1,4 +1,4 @@
-/*! lozad.js - v1.16.0 - 2020-09-10
+/*! lozad.js - v1.16.0 - 2020-12-27
 * https://github.com/ApoorvSaxena/lozad.js
 * Copyright (c) 2020 Apoorv Saxena; Licensed MIT */
 
@@ -39,6 +39,10 @@ const defaultConfig = {
 
       if (element.getAttribute('data-alt')) {
         img.alt = element.getAttribute('data-alt');
+      }
+      
+      if (element.getAttribute('data-style')) {
+        img.style = element.getAttribute('data-style');
       }
 
       if (append) {

--- a/dist/lozad.es.js
+++ b/dist/lozad.es.js
@@ -17,7 +17,7 @@ const isIE = typeof document !== 'undefined' && document.documentMode;
  */
 const support = type => window && window[type];
 
-const validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
+const validAttribute = ['data-iesrc', 'data-alt', 'data-style', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
 
 const defaultConfig = {
   rootMargin: '0px',

--- a/dist/lozad.es.js
+++ b/dist/lozad.es.js
@@ -1,4 +1,4 @@
-/*! lozad.js - v1.16.0 - 2020-12-27
+/*! lozad.js - v1.17.0 - 2020-12-27
 * https://github.com/ApoorvSaxena/lozad.js
 * Copyright (c) 2020 Apoorv Saxena; Licensed MIT */
 
@@ -17,7 +17,7 @@ const isIE = typeof document !== 'undefined' && document.documentMode;
  */
 const support = type => window && window[type];
 
-const validAttribute = ['data-iesrc', 'data-alt', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
+const validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
 
 const defaultConfig = {
   rootMargin: '0px',
@@ -40,7 +40,7 @@ const defaultConfig = {
       if (element.getAttribute('data-alt')) {
         img.alt = element.getAttribute('data-alt');
       }
-      
+
       if (element.getAttribute('data-style')) {
         img.style = element.getAttribute('data-style');
       }

--- a/dist/lozad.js
+++ b/dist/lozad.js
@@ -25,7 +25,7 @@
     return window && window[type];
   };
 
-  var validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
+  var validAttribute = ['data-iesrc', 'data-alt', 'data-style', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
 
   var defaultConfig = {
     rootMargin: '0px',

--- a/dist/lozad.js
+++ b/dist/lozad.js
@@ -1,4 +1,4 @@
-/*! lozad.js - v1.16.0 - 2020-09-10
+/*! lozad.js - v1.16.0 - 2020-12-27
 * https://github.com/ApoorvSaxena/lozad.js
 * Copyright (c) 2020 Apoorv Saxena; Licensed MIT */
 
@@ -47,6 +47,10 @@
 
         if (element.getAttribute('data-alt')) {
           img.alt = element.getAttribute('data-alt');
+        }
+
+        if (element.getAttribute('data-style')) {
+          img.style = element.getAttribute('data-style');
         }
 
         if (append) {

--- a/dist/lozad.js
+++ b/dist/lozad.js
@@ -1,4 +1,4 @@
-/*! lozad.js - v1.16.0 - 2020-12-27
+/*! lozad.js - v1.17.0 - 2020-12-27
 * https://github.com/ApoorvSaxena/lozad.js
 * Copyright (c) 2020 Apoorv Saxena; Licensed MIT */
 
@@ -25,7 +25,7 @@
     return window && window[type];
   };
 
-  var validAttribute = ['data-iesrc', 'data-alt', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
+  var validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
 
   var defaultConfig = {
     rootMargin: '0px',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lozad",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lozad",
   "title": "lozad.js",
   "description": "A light-weight JS library to lazy load any HTML element such as images, ads, videos etc.",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "homepage": "https://github.com/ApoorvSaxena/lozad.js",
   "license": "MIT",
   "scripts": {

--- a/src/lozad.js
+++ b/src/lozad.js
@@ -12,7 +12,7 @@ const isIE = typeof document !== 'undefined' && document.documentMode
  */
 const support = type => window && window[type]
 
-const validAttribute = ['data-iesrc', 'data-alt', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class']
+const validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
 
 const defaultConfig = {
   rootMargin: '0px',
@@ -35,7 +35,7 @@ const defaultConfig = {
       if (element.getAttribute('data-alt')) {
         img.alt = element.getAttribute('data-alt')
       }
-      
+
       if (element.getAttribute('data-style')) {
         img.style = element.getAttribute('data-style')
       }

--- a/src/lozad.js
+++ b/src/lozad.js
@@ -35,6 +35,10 @@ const defaultConfig = {
       if (element.getAttribute('data-alt')) {
         img.alt = element.getAttribute('data-alt')
       }
+      
+      if (element.getAttribute('data-syle')) {
+        img.style = element.getAttribute('data-alt')
+      }
 
       if (append) {
         element.append(img)

--- a/src/lozad.js
+++ b/src/lozad.js
@@ -12,7 +12,7 @@ const isIE = typeof document !== 'undefined' && document.documentMode
  */
 const support = type => window && window[type]
 
-const validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class'];
+const validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class']
 
 const defaultConfig = {
   rootMargin: '0px',

--- a/src/lozad.js
+++ b/src/lozad.js
@@ -12,7 +12,7 @@ const isIE = typeof document !== 'undefined' && document.documentMode
  */
 const support = type => window && window[type]
 
-const validAttribute = ['data-iesrc', 'data-alt', 'data-syle', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class']
+const validAttribute = ['data-iesrc', 'data-alt', 'data-style', 'data-src', 'data-srcset', 'data-background-image', 'data-toggle-class']
 
 const defaultConfig = {
   rootMargin: '0px',

--- a/src/lozad.js
+++ b/src/lozad.js
@@ -36,8 +36,8 @@ const defaultConfig = {
         img.alt = element.getAttribute('data-alt')
       }
       
-      if (element.getAttribute('data-syle')) {
-        img.style = element.getAttribute('data-alt')
+      if (element.getAttribute('data-style')) {
+        img.style = element.getAttribute('data-style')
       }
 
       if (append) {


### PR DESCRIPTION
if I want to use the `picture` tag and would like to add inline styles to the `img` tag, I would need to actually add the `img` tag which would break the lazy loading. To avoid this I adopted the patterern used for the alt tag, `data-alt` attribute on the `picture` tag,