### PR TITLE
Separate loaded check for custom load() function.

### DIFF
--- a/dist/lozad.es.js
+++ b/dist/lozad.es.js
@@ -1,6 +1,6 @@
-/*! lozad.js - v1.16.0 - 2020-09-10
+/*! lozad.js - v1.16.0 - 2021-10-13
 * https://github.com/ApoorvSaxena/lozad.js
-* Copyright (c) 2020 Apoorv Saxena; Licensed MIT */
+* Copyright (c) 2021 Apoorv Saxena; Licensed MIT */
 
 
 /**
@@ -22,6 +22,7 @@ const validAttribute = ['data-iesrc', 'data-alt', 'data-src', 'data-srcset', 'da
 const defaultConfig = {
   rootMargin: '0px',
   threshold: 0,
+  checkKey: 'default',
   enableAutoReload: false,
   load(element) {
     if (element.nodeName.toLowerCase() === 'picture') {
@@ -98,8 +99,12 @@ const defaultConfig = {
   loaded() {}
 };
 
-function markAsLoaded(element) {
-  element.setAttribute('data-loaded', true);
+function getAttr (element) {
+  return element.getAttribute('data-lozaded') || ''
+}
+
+function markAsLoaded (element, checkKey) {
+  element.setAttribute('data-lozaded', `${getAttr(element)} ${checkKey}`.trim());
 }
 
 function preLoad(element) {
@@ -108,26 +113,28 @@ function preLoad(element) {
   }
 }
 
-const isLoaded = element => element.getAttribute('data-loaded') === 'true';
+function isLoaded (element, checkKey) {
+  return -1 !== getAttr(element).indexOf(checkKey)
+}
 
-const onIntersection = (load, loaded) => (entries, observer) => {
+const onIntersection = (config) => (entries, observer) => {
   entries.forEach(entry => {
     if (entry.intersectionRatio > 0 || entry.isIntersecting) {
       observer.unobserve(entry.target);
 
       if (!isLoaded(entry.target)) {
-        load(entry.target);
-        markAsLoaded(entry.target);
-        loaded(entry.target);
+        config.load(entry.target);
+        markAsLoaded(entry.target, config.checkKey);
+        config.loaded(entry.target);
       }
     }
   });
 };
 
-const onMutation = load => entries => {
+const onMutation = config => entries => {
   entries.forEach(entry => {
-    if (isLoaded(entry.target) && entry.type === 'attributes' && validAttribute.indexOf(entry.attributeName) > -1) {
-      load(entry.target);
+    if (isLoaded(entry.target, config.checkKey) && entry.type === 'attributes' && validAttribute.indexOf(entry.attributeName) > -1) {
+      config.load(entry.target);
     }
   });
 };
@@ -144,30 +151,40 @@ const getElements = (selector, root = document) => {
   return root.querySelectorAll(selector)
 };
 
+let checkKeyIncrement = 1;
+
 function lozad (selector = '.lozad', options = {}) {
-  const {root, rootMargin, threshold, enableAutoReload, load, loaded} = Object.assign({}, defaultConfig, options);
+  // set auto-generated checkKey for custom `load` callback if checkKey is not specified
+  if( options.load && ! options.checkKey ){
+    options.checkKey = `loadfunc${ checkKeyIncrement++ }`;
+  }
+
+  let config = Object.assign({}, defaultConfig, options);
   let observer;
   let mutationObserver;
   if (support('IntersectionObserver')) {
-    observer = new IntersectionObserver(onIntersection(load, loaded), {
-      root,
-      rootMargin,
-      threshold
+    observer = new IntersectionObserver(onIntersection(config), {
+      root: config.root,
+      rootMargin: config.rootMargin,
+      threshold: config.threshold
     });
   }
 
-  if (support('MutationObserver') && enableAutoReload) {
-    mutationObserver = new MutationObserver(onMutation(load, loaded));
+  if (support('MutationObserver') && config.enableAutoReload) {
+    mutationObserver = new MutationObserver(onMutation(config));
   }
 
-  const elements = getElements(selector, root);
-  for (let i = 0; i < elements.length; i++) {
-    preLoad(elements[i]);
+  // do preLoad() only for default load callback
+  if( 'default' === config.checkKey ){
+    const elements = getElements(selector, config.root);
+    for (let i = 0; i < elements.length; i++) {
+      preLoad(elements[i]);
+    }
   }
 
   return {
     observe() {
-      const elements = getElements(selector, root);
+      const elements = getElements(selector, config.root);
 
       for (let i = 0; i < elements.length; i++) {
         if (isLoaded(elements[i])) {
@@ -175,7 +192,7 @@ function lozad (selector = '.lozad', options = {}) {
         }
 
         if (observer) {
-          if (mutationObserver && enableAutoReload) {
+          if (mutationObserver && config.enableAutoReload) {
             mutationObserver.observe(elements[i], {subtree: true, attributes: true, attributeFilter: validAttribute});
           }
 
@@ -183,9 +200,9 @@ function lozad (selector = '.lozad', options = {}) {
           continue
         }
 
-        load(elements[i]);
-        markAsLoaded(elements[i]);
-        loaded(elements[i]);
+        config.load(elements[i]);
+        markAsLoaded(elements[i], config.checkKey);
+        config.loaded(elements[i]);
       }
     },
     triggerLoad(element) {
@@ -193,9 +210,9 @@ function lozad (selector = '.lozad', options = {}) {
         return
       }
 
-      load(element);
-      markAsLoaded(element);
-      loaded(element);
+      config.load(element);
+      markAsLoaded(element, config.checkKey);
+      config.loaded(element);
     },
     observer,
     mutationObserver


### PR DESCRIPTION
To illustrate the problem, here is an example.

Suppose we have an HTML element:

```html
<div class="lozad animation" data-background-image="URL">
    some html
</div>
```

Now let's attach two lozad observers to the same element:

```js
// first default call
lozad().observe()

// second - custom call
const el = document.querySelector('.animation')
lozad( el, {
    load: function(){
        // some code for animation
    }
} ).observe() 
```

In both cases, the same check is triggered to determine whether lozad has already loaded the element. As a result, only the first call works. In the second call, lozad sees that the element is already marked as loaded and skips executing our custom `load` function.

Also,

It is better to use a unique name for the `data-loaded` attribute, because it is a fairly common name that might be used by another script. If that happens, it can cause an unpredictable conflict. A more unique attribute name would be better, such as `data-lozaded`.
