### PR TITLE
Add `Element.prototype.append` to example polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The `active` class will be toggled on the element when it enters the browser’s
 
 Available in [latest browsers](http://caniuse.com/#feat=intersectionobserver). If browser support is not available, then make use of [polyfill](https://www.npmjs.com/package/intersection-observer).
 
-For IE11 support, please make use of these [polyfills](https://polyfill.io/v3/polyfill.min.js?features=Element.prototype.append%2CObject.assign%2CIntersectionObserver).
+For IE11 support, please make use of these [polyfills](https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Element.prototype.append%2CObject.assign%2CIntersectionObserver).
 
 ## FAQs
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The `active` class will be toggled on the element when it enters the browser’s
 
 Available in [latest browsers](http://caniuse.com/#feat=intersectionobserver). If browser support is not available, then make use of [polyfill](https://www.npmjs.com/package/intersection-observer).
 
-For IE11 support, please make use of these [polyfills](https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Object.assign%2CIntersectionObserver).
+For IE11 support, please make use of these [polyfills](https://polyfill.io/v3/polyfill.min.js?features=Element.prototype.append%2CObject.assign%2CIntersectionObserver).
 
 ## FAQs
 


### PR DESCRIPTION
This PR adds `Element.prototype.append` to the example polyfill.io URL in the readme for IE11 support.

----

- Fixes #215