### PR TITLE
Remove unwanted horizontal scrollbars for medium size

### DIFF
--- a/demo/assets/css/main.css
+++ b/demo/assets/css/main.css
@@ -1099,6 +1099,12 @@ body.loading #main .thumb {
 	}
 }
 
+@media screen and (min-width: 768px) {
+	body {
+		overflow-x: hidden;
+	}
+}
+
 .social-wrap {
 	margin-top: 5px;
 }


### PR DESCRIPTION
Hi @ApoorvSaxena , I made little changes to the demo page, namely removing the horizontal scrollbar for medium (width: 768px) and larger sizes because it looks less slick. I hope my little contribution can be useful

New:
![image](https://user-images.githubusercontent.com/26623057/194561349-93fa6df6-6b06-4325-8ffd-452244d4a1f2.png)

Old:
![image](https://user-images.githubusercontent.com/26623057/194561714-3697333b-33dd-4b99-b66b-c8abb0f0a7d4.png)
