### PR TITLE
Updated broken link to Intersection Observer API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and many more...
 
 Existing lazy loading libraries hook up to the scroll event or use a periodic timer and call `getBoundingClientRect()` on elements that need to be lazy loaded. This approach, however, is painfully slow as each call to `getBoundingClientRect()` forces the browser to re-layout the entire page and will introduce considerable jank to your website.
 
-Making this more efficient and performant is what [IntersectionObserver](https://developers.google.com/web/updates/2016/04/intersectionobserver) is designed for, and it’s landed in Chrome 51. IntersectionObservers let you know when an observed element enters or exits the browser’s viewport.
+Making this more efficient and performant is what [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) is designed for, and it’s landed in Chrome 51. IntersectionObservers let you know when an observed element enters or exits the browser’s viewport.
 
 ## Install
 


### PR DESCRIPTION
Updated the broken link to the proper Intersection Observer API documentation. Closes issue #292  